### PR TITLE
Install the header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,6 @@ include_directories(
     ${catkin_INCLUDE_DIRS}
     )
 
+install(DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+    )


### PR DESCRIPTION
According to the [catkin reference](http://docs.ros.org/api/catkin/html/howto/format2/building_libraries.html) we should also install the header files we are exporting. With this change, you can make .debs of this package that actually work.